### PR TITLE
Spike: implement polly retry for api call failures in listeners

### DIFF
--- a/TenureListener.Tests/Gateway/AccountApiTests.cs
+++ b/TenureListener.Tests/Gateway/AccountApiTests.cs
@@ -18,7 +18,7 @@ namespace TenureListener.Tests.Gateway
     {
         private readonly Mock<IApiGateway> _mockApiGateway;
         private readonly PolicyRegistry _mockPolicyRegistry;
-        
+
         private static readonly Guid _id = Guid.NewGuid();
         private static readonly Guid _correlationId = Guid.NewGuid();
         private const string AccountApiRoute = "https://some-domain.com/api";
@@ -95,10 +95,10 @@ namespace TenureListener.Tests.Gateway
         {
             var mockPolicy = new Mock<IAsyncPolicy>();
             _mockPolicyRegistry[PolicyConstants.WaitAndRetry] = mockPolicy.Object;
-            
+
             var sut = new AccountApi(_mockApiGateway.Object, _mockPolicyRegistry);
             await sut.GetAccountByIdAsync(_id, _correlationId).ConfigureAwait(false);
-            
+
             mockPolicy.Verify(policy => policy.ExecuteAsync(It.IsAny<Func<Task<AccountResponseObject>>>()));
         }
     }

--- a/TenureListener.Tests/Gateway/AccountApiTests.cs
+++ b/TenureListener.Tests/Gateway/AccountApiTests.cs
@@ -4,9 +4,11 @@ using Hackney.Core.Http;
 using Moq;
 using System;
 using System.Threading.Tasks;
+using Polly;
+using Polly.Registry;
 using TenureListener.Domain.Account;
 using TenureListener.Gateway;
-using TenureListener.Gateway.Interfaces;
+using TenureListener.Infrastructure;
 using Xunit;
 
 namespace TenureListener.Tests.Gateway
@@ -15,7 +17,8 @@ namespace TenureListener.Tests.Gateway
     public class AccountApiTests
     {
         private readonly Mock<IApiGateway> _mockApiGateway;
-
+        private readonly PolicyRegistry _mockPolicyRegistry;
+        
         private static readonly Guid _id = Guid.NewGuid();
         private static readonly Guid _correlationId = Guid.NewGuid();
         private const string AccountApiRoute = "https://some-domain.com/api";
@@ -32,6 +35,11 @@ namespace TenureListener.Tests.Gateway
             _mockApiGateway.SetupGet(x => x.ApiName).Returns(ApiName);
             _mockApiGateway.SetupGet(x => x.ApiRoute).Returns(AccountApiRoute);
             _mockApiGateway.SetupGet(x => x.ApiToken).Returns(AccountApiToken);
+
+            _mockPolicyRegistry = new PolicyRegistry
+            {
+                { PolicyConstants.WaitAndRetry, Policy.NoOpAsync() }
+            };
         }
 
         private static string Route => $"{AccountApiRoute}/accounts/{_id}";
@@ -40,7 +48,7 @@ namespace TenureListener.Tests.Gateway
         [Fact]
         public void ConstructorTestInitialisesApiGateway()
         {
-            new AccountApi(_mockApiGateway.Object);
+            new AccountApi(_mockApiGateway.Object, _mockPolicyRegistry);
             _mockApiGateway.Verify(x => x.Initialise(ApiName, AccountApiUrlKey, AccountApiTokenKey, null),
                                    Times.Once);
         }
@@ -52,7 +60,7 @@ namespace TenureListener.Tests.Gateway
             _mockApiGateway.Setup(x => x.GetByIdAsync<AccountResponseObject>(Route, _id, _correlationId))
                            .ThrowsAsync(new Exception(exMessage));
 
-            var sut = new AccountApi(_mockApiGateway.Object);
+            var sut = new AccountApi(_mockApiGateway.Object, _mockPolicyRegistry);
             Func<Task<AccountResponseObject>> func =
                 async () => await sut.GetAccountByIdAsync(_id, _correlationId).ConfigureAwait(false);
 
@@ -62,7 +70,7 @@ namespace TenureListener.Tests.Gateway
         [Fact]
         public async Task GetAccountByIdAsyncNotFoundReturnsNull()
         {
-            var sut = new AccountApi(_mockApiGateway.Object);
+            var sut = new AccountApi(_mockApiGateway.Object, _mockPolicyRegistry);
             var result = await sut.GetAccountByIdAsync(_id, _correlationId).ConfigureAwait(false);
 
             result.Should().BeNull();
@@ -76,10 +84,22 @@ namespace TenureListener.Tests.Gateway
             _mockApiGateway.Setup(x => x.GetByIdAsync<AccountResponseObject>(Route, _id, _correlationId))
                            .ReturnsAsync(account);
 
-            var sut = new AccountApi(_mockApiGateway.Object);
+            var sut = new AccountApi(_mockApiGateway.Object, _mockPolicyRegistry);
             var result = await sut.GetAccountByIdAsync(_id, _correlationId).ConfigureAwait(false);
 
             result.Should().BeEquivalentTo(account);
+        }
+
+        [Fact]
+        public async Task GetAccountByIdUsesWaitAndRetryPolicy()
+        {
+            var mockPolicy = new Mock<IAsyncPolicy>();
+            _mockPolicyRegistry[PolicyConstants.WaitAndRetry] = mockPolicy.Object;
+            
+            var sut = new AccountApi(_mockApiGateway.Object, _mockPolicyRegistry);
+            await sut.GetAccountByIdAsync(_id, _correlationId).ConfigureAwait(false);
+            
+            mockPolicy.Verify(policy => policy.ExecuteAsync(It.IsAny<Func<Task<AccountResponseObject>>>()));
         }
     }
 }

--- a/TenureListener/Gateway/AccountApi.cs
+++ b/TenureListener/Gateway/AccountApi.cs
@@ -23,7 +23,7 @@ namespace TenureListener.Gateway
         {
             _apiGateway = apiGateway;
             _policyRegistry = policyRegistry;
-            
+
             _apiGateway.Initialise(ApiName, AccountApiUrl, AccountApiToken);
         }
 
@@ -31,7 +31,7 @@ namespace TenureListener.Gateway
         public async Task<AccountResponseObject> GetAccountByIdAsync(Guid id, Guid correlationId)
         {
             var route = $"{_apiGateway.ApiRoute}/accounts/{id}";
-            
+
             return await _policyRegistry
                 .Get<IAsyncPolicy>(PolicyConstants.WaitAndRetry)
                 .ExecuteAsync(() => _apiGateway.GetByIdAsync<AccountResponseObject>(route, id, correlationId));

--- a/TenureListener/Gateway/AccountApi.cs
+++ b/TenureListener/Gateway/AccountApi.cs
@@ -2,8 +2,11 @@ using Hackney.Core.Http;
 using Hackney.Core.Logging;
 using System;
 using System.Threading.Tasks;
+using Polly;
+using Polly.Registry;
 using TenureListener.Domain.Account;
 using TenureListener.Gateway.Interfaces;
+using TenureListener.Infrastructure;
 
 namespace TenureListener.Gateway
 {
@@ -14,10 +17,13 @@ namespace TenureListener.Gateway
         private const string AccountApiToken = "AccountApiToken";
 
         private readonly IApiGateway _apiGateway;
+        private readonly IReadOnlyPolicyRegistry<string> _policyRegistry;
 
-        public AccountApi(IApiGateway apiGateway)
+        public AccountApi(IApiGateway apiGateway, IReadOnlyPolicyRegistry<string> policyRegistry)
         {
             _apiGateway = apiGateway;
+            _policyRegistry = policyRegistry;
+            
             _apiGateway.Initialise(ApiName, AccountApiUrl, AccountApiToken);
         }
 
@@ -25,7 +31,10 @@ namespace TenureListener.Gateway
         public async Task<AccountResponseObject> GetAccountByIdAsync(Guid id, Guid correlationId)
         {
             var route = $"{_apiGateway.ApiRoute}/accounts/{id}";
-            return await _apiGateway.GetByIdAsync<AccountResponseObject>(route, id, correlationId);
+            
+            return await _policyRegistry
+                .Get<IAsyncPolicy>(PolicyConstants.WaitAndRetry)
+                .ExecuteAsync(() => _apiGateway.GetByIdAsync<AccountResponseObject>(route, id, correlationId));
         }
     }
 }

--- a/TenureListener/Infrastructure/PolicyConstants.cs
+++ b/TenureListener/Infrastructure/PolicyConstants.cs
@@ -1,4 +1,4 @@
-﻿namespace TenureListener.Infrastructure
+namespace TenureListener.Infrastructure
 {
     public static class PolicyConstants
     {

--- a/TenureListener/Infrastructure/PolicyConstants.cs
+++ b/TenureListener/Infrastructure/PolicyConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace TenureListener.Infrastructure
+{
+    public static class PolicyConstants
+    {
+        public const string WaitAndRetry = "WaitAndRetry";
+    }
+}

--- a/TenureListener/Infrastructure/ServiceCollectionExtensions.cs
+++ b/TenureListener/Infrastructure/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net.Http;
 using Hackney.Core.Http.Exceptions;
 using Microsoft.Extensions.DependencyInjection;

--- a/TenureListener/Infrastructure/ServiceCollectionExtensions.cs
+++ b/TenureListener/Infrastructure/ServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Net.Http;
+using Hackney.Core.Http.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
+using Polly;
+
+namespace TenureListener.Infrastructure
+{
+    public static class ServiceCollectionExtensions
+    {
+        // can be moved to Hackney.Http.Core
+        public static void AddPollyRegistry(this IServiceCollection services)
+        {
+            var registry = services.AddPolicyRegistry();
+
+            // 3 repeats with 100 ms delay in between 
+            registry[PolicyConstants.WaitAndRetry] = Policy
+                .Handle<GetFromApiException>()
+                .Or<HttpRequestException>()
+                .WaitAndRetryAsync(3, _ => TimeSpan.FromMilliseconds(100));
+        }
+    }
+}

--- a/TenureListener/SqsFunction.cs
+++ b/TenureListener/SqsFunction.cs
@@ -67,7 +67,7 @@ namespace TenureListener
 
             services.AddApiGateway();
             services.AddPollyRegistry();
-            
+
             base.ConfigureServices(services);
         }
 

--- a/TenureListener/SqsFunction.cs
+++ b/TenureListener/SqsFunction.cs
@@ -7,13 +7,17 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using Hackney.Core.Http.Exceptions;
+using Polly;
 using TenureListener.Boundary;
 using TenureListener.Factories;
 using TenureListener.Gateway;
 using TenureListener.Gateway.Interfaces;
+using TenureListener.Infrastructure;
 using TenureListener.UseCase;
 using TenureListener.UseCase.Interfaces;
 
@@ -62,7 +66,8 @@ namespace TenureListener
             services.AddScoped<ITenureInfoGateway, TenureInfoGateway>();
 
             services.AddApiGateway();
-
+            services.AddPollyRegistry();
+            
             base.ConfigureServices(services);
         }
 

--- a/TenureListener/TenureListener.csproj
+++ b/TenureListener/TenureListener.csproj
@@ -33,6 +33,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.0" />
+    <PackageReference Include="Polly" Version="7.2.3" />
   </ItemGroup>
     
   <ItemGroup>


### PR DESCRIPTION
## Link to JIRA ticket

[JIRA ticket](https://hackney.atlassian.net/jira/software/projects/MTTL/boards/47?selectedIssue=MTTL-1946)

## Describe this PR

Added basic wait-and-retry Polly policy to API calls.

More robust solution would require changes in shared Hackney.Core.Http library. Proposed changes are described in [spike document](https://docs.google.com/document/d/1gLwslJdTZKBGn-uZcWDsxNOkV6ucO051CacIJQTnaks).