### PR TITLE
Do not update tenant name on inactive tenures

### DIFF
--- a/TenureListener.Tests/E2ETests/Steps/UpdatePersonDetailsOnTenureSteps.cs
+++ b/TenureListener.Tests/E2ETests/Steps/UpdatePersonDetailsOnTenureSteps.cs
@@ -86,7 +86,7 @@ namespace TenureListener.Tests.E2ETests.Steps
         private void ValidateHouseholdMemberName(TenureInformation tenure, PersonResponseObject personResponse)
         {
             var householdMember = tenure.HouseholdMembers.First(x => x.Id == personResponse.Id);
-            if (tenure.IsActive && householdMember.PersonTenureType == PersonTenureType.Tenant)
+            if (tenure.IsActive || householdMember.PersonTenureType != PersonTenureType.Tenant)
             {
                 householdMember.FullName.Should().BeEquivalentTo(personResponse.GetFullName());
             }

--- a/TenureListener.Tests/E2ETests/Steps/UpdatePersonDetailsOnTenureSteps.cs
+++ b/TenureListener.Tests/E2ETests/Steps/UpdatePersonDetailsOnTenureSteps.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Hackney.Shared.Person.Boundary.Response;
 using Hackney.Shared.Person.Domain;
 using Hackney.Shared.Tenure.Domain;
+using Hackney.Shared.Tenure.Factories;
 using Hackney.Shared.Tenure.Infrastructure;
 using Moq;
 using System;
@@ -82,15 +83,28 @@ namespace TenureListener.Tests.E2ETests.Steps
             lastHouseholdMember.PersonTenureType.Should().Be(tenureInfo.TenureType.GetPersonTenureType(isResponsible));
         }
 
+        private void ValidateHouseholdMemberName(TenureInformation tenure, PersonResponseObject personResponse)
+        {
+            var householdMember = tenure.HouseholdMembers.First(x => x.Id == personResponse.Id);
+            if (tenure.IsActive && householdMember.PersonTenureType == PersonTenureType.Tenant)
+            {
+                householdMember.FullName.Should().BeEquivalentTo(personResponse.GetFullName());
+            }
+            else
+            {
+                householdMember.FullName.Should().NotBe(personResponse.GetFullName());
+            }
+        }
+
         public async Task ThenAllTenuresAreUpdated(IDynamoDBContext dbContext, PersonResponseObject personResponse)
         {
             foreach (var personTenureId in personResponse.Tenures.Select(x => x.Id))
             {
                 var tenure = await dbContext.LoadAsync<TenureInformationDb>(personTenureId).ConfigureAwait(false);
 
-                var householdMember = tenure.HouseholdMembers.First(x => x.Id == personResponse.Id);
-                householdMember.FullName.Should().BeEquivalentTo(personResponse.GetFullName());
+                var householdMember = tenure.HouseholdMembers.Find(x => x.Id == personResponse.Id);
                 householdMember.DateOfBirth.Should().Be(DateTime.Parse(personResponse.DateOfBirth));
+                ValidateHouseholdMemberName(tenure.ToDomain(), personResponse);
             }
         }
 

--- a/TenureListener.Tests/UseCase/UpdatePersonDetailsOnTenureTests.cs
+++ b/TenureListener.Tests/UseCase/UpdatePersonDetailsOnTenureTests.cs
@@ -58,17 +58,24 @@ namespace TenureListener.Tests.UseCase
                            .Create();
         }
 
-        private TenureInformation CreateTenure(Guid entityId, PersonResponseObject person)
+        private TenureInformation CreateTenure(Guid entityId, PersonResponseObject person, bool isActive, bool isTenant)
         {
             var householdMembers = _fixture.Build<HouseholdMembers>()
                                            .With(x => x.Id, person.Id)
                                            .With(x => x.DateOfBirth, DateTime.Parse(person.DateOfBirth))
                                            .With(x => x.FullName, person.GetFullName())
+                                           .With(x => x.PersonTenureType, isTenant ? PersonTenureType.Tenant : PersonTenureType.HouseholdMember)
                                            .CreateMany(1);
             return _fixture.Build<TenureInformation>()
                            .With(x => x.Id, entityId)
                            .With(x => x.HouseholdMembers, householdMembers)
+                           .With(x => x.EndOfTenureDate, isActive ? DateTime.UtcNow.AddDays(10) : DateTime.UtcNow.AddDays(-10))
                            .Create();
+        }
+
+        private TenureInformation CreateTenure(Guid entityId, PersonResponseObject person)
+        {
+            return CreateTenure(entityId, person, true, true);
         }
 
         private EntityEventSns CreateMessage(string eventType = EventTypes.PersonUpdatedEvent)
@@ -282,6 +289,75 @@ namespace TenureListener.Tests.UseCase
             _mockLogger.VerifyAny(LogLevel.Warning, Times.Never());
             _mockGateway.Verify(x => x.UpdateTenureInfoAsync(It.Is<TenureInformation>(y => VerifyUpdatedTenure(y, _person))),
                                 Times.Exactly(numTenures));
+        }
+
+        [Fact]
+        public async Task PersonNameIsUpdatedOnlyOnActiveTenures()
+        {
+            int numActiveTenures = 5;
+            _person.Tenures = _fixture.Build<TenureResponseObject>()
+                                            .With(x => x.IsActive, true)
+                                            .CreateMany(numActiveTenures);
+
+            int numInactiveTenures = 2;
+            _person.Tenures = _person.Tenures.Concat(_fixture.Build<TenureResponseObject>()
+                                                             .With(x => x.IsActive, false)
+                                                             .CreateMany(numInactiveTenures));
+            var tenures = new List<TenureInformation>();
+            foreach (var personTenure in _person.Tenures)
+            {
+                var tenureInfo = CreateTenure(personTenure.Id, _person, personTenure.IsActive, true);
+                tenures.Add(tenureInfo);
+                _mockGateway.Setup(x => x.GetTenureInfoByIdAsync(personTenure.Id))
+                            .ReturnsAsync(tenureInfo);
+            }
+
+            _mockPersonApi.Setup(x => x.GetPersonByIdAsync(_message.EntityId, _message.CorrelationId))
+                          .ReturnsAsync(_person);
+
+            _person.FirstName = "Bob";
+            _person.Surname = "Roberts";
+
+            await _sut.ProcessMessageAsync(_message).ConfigureAwait(false);
+
+            _mockPersonApi.Verify(x => x.GetPersonByIdAsync(_message.EntityId, _message.CorrelationId), Times.Once);
+            _mockGateway.Verify(x => x.GetTenureInfoByIdAsync(It.IsAny<Guid>()), Times.Exactly(numActiveTenures + numInactiveTenures));
+            _mockLogger.VerifyAny(LogLevel.Warning, Times.Never());
+            _mockGateway.Verify(x => x.UpdateTenureInfoAsync(It.Is<TenureInformation>(y => VerifyUpdatedTenure(y, _person))),
+                                Times.Exactly(numActiveTenures));
+        }
+
+        [Fact]
+        public async Task PersonNameIsUpdatedOnlyOnTenuresWherePersonIsTenant()
+        {
+            int numTenantTenures = 5;
+            int numNotTenantTenures = 2;
+            _person.Tenures = _fixture.CreateMany<TenureResponseObject>(numTenantTenures + numNotTenantTenures);
+
+            var tenures = new List<TenureInformation>();
+            foreach (var item in _person.Tenures.Select((value, index) => new { index, value })) // getting index in foreach
+            {
+                var personTenure = item.value;
+                var tenureInfo = CreateTenure(personTenure.Id, _person, true, (item.index < numTenantTenures));
+                // person is tenant on first 5 tenures
+                tenures.Add(tenureInfo);
+                _mockGateway.Setup(x => x.GetTenureInfoByIdAsync(personTenure.Id))
+                            .ReturnsAsync(tenureInfo);
+            }
+
+            _mockPersonApi.Setup(x => x.GetPersonByIdAsync(_message.EntityId, _message.CorrelationId))
+                          .ReturnsAsync(_person);
+
+            _person.FirstName = "Bob";
+            _person.Surname = "Roberts";
+
+            await _sut.ProcessMessageAsync(_message).ConfigureAwait(false);
+
+            _mockPersonApi.Verify(x => x.GetPersonByIdAsync(_message.EntityId, _message.CorrelationId), Times.Once);
+            _mockGateway.Verify(x => x.GetTenureInfoByIdAsync(It.IsAny<Guid>()), Times.Exactly(numTenantTenures + numNotTenantTenures));
+            _mockLogger.VerifyAny(LogLevel.Warning, Times.Never());
+            _mockGateway.Verify(x => x.UpdateTenureInfoAsync(It.Is<TenureInformation>(y => VerifyUpdatedTenure(y, _person))),
+                                Times.Exactly(numTenantTenures));
         }
     }
 }

--- a/TenureListener.Tests/UseCase/UpdatePersonDetailsOnTenureTests.cs
+++ b/TenureListener.Tests/UseCase/UpdatePersonDetailsOnTenureTests.cs
@@ -292,7 +292,7 @@ namespace TenureListener.Tests.UseCase
         }
 
         [Fact]
-        public async Task PersonNameIsUpdatedOnlyOnActiveTenures()
+        public async Task PersonNameIsUpdatedOnAllActiveTenures()
         {
             int numActiveTenures = 5;
             _person.Tenures = _fixture.Build<TenureResponseObject>()
@@ -327,7 +327,7 @@ namespace TenureListener.Tests.UseCase
         }
 
         [Fact]
-        public async Task PersonNameIsUpdatedOnlyOnTenuresWherePersonIsTenant()
+        public async Task PersonNameIsUpdatedOnInactiveTenuresWherePersonIsNotTenant()
         {
             int numTenantTenures = 5;
             int numNotTenantTenures = 2;
@@ -336,7 +336,7 @@ namespace TenureListener.Tests.UseCase
             foreach (var item in _person.Tenures.Select((value, index) => new { index, value })) // getting index in foreach
             {
                 var personTenure = item.value;
-                var tenureInfo = CreateTenure(personTenure.Id, _person, true, (item.index < numTenantTenures));
+                var tenureInfo = CreateTenure(personTenure.Id, _person, false, (item.index < numTenantTenures));
                 // person is tenant on first 5 tenures
                 _mockGateway.Setup(x => x.GetTenureInfoByIdAsync(personTenure.Id))
                             .ReturnsAsync(tenureInfo);
@@ -354,7 +354,7 @@ namespace TenureListener.Tests.UseCase
             _mockGateway.Verify(x => x.GetTenureInfoByIdAsync(It.IsAny<Guid>()), Times.Exactly(numTenantTenures + numNotTenantTenures));
             _mockLogger.VerifyAny(LogLevel.Warning, Times.Never());
             _mockGateway.Verify(x => x.UpdateTenureInfoAsync(It.Is<TenureInformation>(y => VerifyUpdatedTenure(y, _person))),
-                                Times.Exactly(numTenantTenures));
+                                Times.Exactly(numNotTenantTenures));
         }
     }
 }

--- a/TenureListener.Tests/UseCase/UpdatePersonDetailsOnTenureTests.cs
+++ b/TenureListener.Tests/UseCase/UpdatePersonDetailsOnTenureTests.cs
@@ -303,11 +303,10 @@ namespace TenureListener.Tests.UseCase
             _person.Tenures = _person.Tenures.Concat(_fixture.Build<TenureResponseObject>()
                                                              .With(x => x.IsActive, false)
                                                              .CreateMany(numInactiveTenures));
-            var tenures = new List<TenureInformation>();
+
             foreach (var personTenure in _person.Tenures)
             {
                 var tenureInfo = CreateTenure(personTenure.Id, _person, personTenure.IsActive, true);
-                tenures.Add(tenureInfo);
                 _mockGateway.Setup(x => x.GetTenureInfoByIdAsync(personTenure.Id))
                             .ReturnsAsync(tenureInfo);
             }
@@ -334,13 +333,11 @@ namespace TenureListener.Tests.UseCase
             int numNotTenantTenures = 2;
             _person.Tenures = _fixture.CreateMany<TenureResponseObject>(numTenantTenures + numNotTenantTenures);
 
-            var tenures = new List<TenureInformation>();
             foreach (var item in _person.Tenures.Select((value, index) => new { index, value })) // getting index in foreach
             {
                 var personTenure = item.value;
                 var tenureInfo = CreateTenure(personTenure.Id, _person, true, (item.index < numTenantTenures));
                 // person is tenant on first 5 tenures
-                tenures.Add(tenureInfo);
                 _mockGateway.Setup(x => x.GetTenureInfoByIdAsync(personTenure.Id))
                             .ReturnsAsync(tenureInfo);
             }

--- a/TenureListener/UseCase/UpdatePersonDetailsOnTenure.cs
+++ b/TenureListener/UseCase/UpdatePersonDetailsOnTenure.cs
@@ -81,7 +81,7 @@ namespace TenureListener.UseCase
                         _logger.LogWarning($"Person record (id: {person.Id}) has tenure for id {tenureId} but is not listed in the tenure's household members.");
                         continue;
                     }
-                    
+
                     var isUpdated = UpdateTenureRecord(person, tenureHouseholdMember, tenure);
                     if (isUpdated) await _gateway.UpdateTenureInfoAsync(tenure).ConfigureAwait(false);
                 }

--- a/TenureListener/UseCase/UpdatePersonDetailsOnTenure.cs
+++ b/TenureListener/UseCase/UpdatePersonDetailsOnTenure.cs
@@ -38,13 +38,15 @@ namespace TenureListener.UseCase
                 isUpdated = true;
             }
 
-            // Get new name if updated & person is a named tenure holder of an active tenure
-            if ((person.GetFullName() != tenureHouseholdMember.FullName)
-                && (tenure.IsActive)
-                && (tenureHouseholdMember.PersonTenureType == PersonTenureType.Tenant))
+            // Get new name if updated
+            if (person.GetFullName() != tenureHouseholdMember.FullName)
             {
-                tenureHouseholdMember.FullName = person.GetFullName();
-                isUpdated = true;
+                if (tenure.IsActive || tenureHouseholdMember.PersonTenureType != PersonTenureType.Tenant)
+                // only update if tenure is active or person is not named tenure holder
+                {
+                    tenureHouseholdMember.FullName = person.GetFullName();
+                    isUpdated = true;
+                }
             }
 
             return isUpdated;


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-3320

## Describe this PR

When a Change Of Name process is completed, a tenant's name is updated. However, their name should only change on their active tenure (where they are a named tenure holder), not all (active & inactive) tenures.

This PR implements this change, so only the active tenure is changed.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly