### PR TITLE
Update tenure shared from version 0.20.0 to 0.24.0

### DIFF
--- a/TenureListener/TenureListener.csproj
+++ b/TenureListener/TenureListener.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.63.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
     <PackageReference Include="Hackney.Shared.Person" Version="0.9.0" />
-    <PackageReference Include="Hackney.Shared.Tenure" Version="0.20.0" />
+    <PackageReference Include="Hackney.Shared.Tenure" Version="0.24.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Link to JIRA ticket

[Backend only: Allow deferred rent account number creation.](https://hackney.atlassian.net/browse/HT20-661)

## Describe this PR

### *What is the problem we're trying to solve*

Update tenure shared from version 0.20.0 to 0.24.0, so that the listener recognises the new `TenureAcceptedDate`  field.

### *What changes have we introduced*

- The new `TenureAcceptedDate`  field.
- From a previous version - allow editing the `PotentialEndDate`.



