### PR TITLE
Fix `development` environment Terraform deployment not applying the infrastructure changes.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
   terraform-apply-development:
     executor: docker-terraform
     steps:
-      - terraform-init-then-plan:
+      - terraform-apply:
           environment: "development"
   terraform-init-and-plan-staging:
     executor: docker-terraform


### PR DESCRIPTION
# What:
 - Fix `housing-development` terraform infrastructure deployment job failing to deploy infrastructure.

# Why:
 - Will be later needed to create a development security group.

# Notes:
 - The development terraform deployment was referencing the plan job rather than apply.