### PR TITLE
Add missing security group ids and replace non-existing subnet ids `[Pt2]`.

### DIFF
--- a/TenureListener/serverless.yml
+++ b/TenureListener/serverless.yml
@@ -123,8 +123,8 @@ custom:
       securityGroupIds:
         - sg-01c5530a6d9e89840
       subnetIds:
-        - subnet-
-        - subnet-
+        - subnet-0140d06fb84fdb547
+        - subnet-05ce390ba88c42bfd
     staging:
       subnetIds:
         - subnet-0ea0020a44b98a2ca

--- a/TenureListener/serverless.yml
+++ b/TenureListener/serverless.yml
@@ -120,6 +120,8 @@ resources:
 custom:
   vpc:
     development:
+      securityGroupIds:
+        - sg-01c5530a6d9e89840
       subnetIds:
         - subnet-0deabb5d8fb9c3446
         - subnet-000b89c249f12a8ad

--- a/TenureListener/serverless.yml
+++ b/TenureListener/serverless.yml
@@ -132,6 +132,8 @@ custom:
         - subnet-0ea0020a44b98a2ca
         - subnet-0743d86e9b362fa38
     production:
+      securityGroupIds:
+        - sg-078a354755b8a7604
       subnetIds:
         - subnet-0beb266003a56ca82
         - subnet-06a697d86a9b6ed01

--- a/TenureListener/serverless.yml
+++ b/TenureListener/serverless.yml
@@ -123,12 +123,12 @@ custom:
       securityGroupIds:
         - sg-01c5530a6d9e89840
       subnetIds:
-        - subnet-0ea0020a44b98a2ca
-        - subnet-0743d86e9b362fa38
+        - subnet-
+        - subnet-
     staging:
       subnetIds:
-        - subnet-06d3de1bd9181b0d7
-        - subnet-0ed7d7713d1127656
+        - subnet-0ea0020a44b98a2ca
+        - subnet-0743d86e9b362fa38
     production:
       subnetIds:
         - subnet-01d3657f97a243261

--- a/TenureListener/serverless.yml
+++ b/TenureListener/serverless.yml
@@ -126,6 +126,8 @@ custom:
         - subnet-0140d06fb84fdb547
         - subnet-05ce390ba88c42bfd
     staging:
+      securityGroupIds:
+        - sg-0502347dbca4f030d
       subnetIds:
         - subnet-0ea0020a44b98a2ca
         - subnet-0743d86e9b362fa38

--- a/TenureListener/serverless.yml
+++ b/TenureListener/serverless.yml
@@ -123,8 +123,8 @@ custom:
       securityGroupIds:
         - sg-01c5530a6d9e89840
       subnetIds:
-        - subnet-0deabb5d8fb9c3446
-        - subnet-000b89c249f12a8ad
+        - subnet-0ea0020a44b98a2ca
+        - subnet-0743d86e9b362fa38
     staging:
       subnetIds:
         - subnet-06d3de1bd9181b0d7

--- a/TenureListener/serverless.yml
+++ b/TenureListener/serverless.yml
@@ -131,5 +131,5 @@ custom:
         - subnet-0743d86e9b362fa38
     production:
       subnetIds:
-        - subnet-01d3657f97a243261
-        - subnet-0b7b8fea07efabf34
+        - subnet-0beb266003a56ca82
+        - subnet-06a697d86a9b6ed01


### PR DESCRIPTION
# What: 
 - Update `serverless.yml` non-existent VPC subnet ids with the private ones.
 - Update `serverless.yml` to include missing VPC security groups to be applied to tenure listener.

# Why:
 - To resolve the AWS induced serverless framework pipeline error that requires for a security group to be specified to attach the listener lambda to be run within the VPC for security reasons.
 - The subnet ids being non-existent wasn't picked up before, because serverless deployment has never reach a point where it would attempt to attach lambda to the VPC because of the missing inputs.

# Notes:
 - This PR is a continuation of PR #79.