### PR TITLE
Minor pipeline improvement, tests dockerfile trim, and better readme.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,11 +125,7 @@ commands:
       - *attach_workspace
       - checkout
       - setup_remote_docker
-      - run:
-          name: Install Node.js
-          command: |
-            curl -sL https://deb.nodesource.com/setup_18.x | bash -
-            apt-get update && apt-get install -y nodejs
+      - node/install
       - run:
           name: Install serverless CLI
           command: npm i -g serverless

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
   sonarcloud: sonarsource/sonarcloud@2.0.0
+  node: circleci/node@6.3.0
 
 executors:
   docker-python:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# tenure-listener
-Listener application implementing an AWS function to receive messages that will result in updates to tenure information
+# Tenure Listener
+
+One of the Manage My Home _(MMH)_ solution event-driven applications that updates the Tenure DynamoDB
+table documents _(records)_ by listenening and processing the following events:
+
+1. PersonCreatedEvent _(only V1) - V1 appears to mean 'PersonAddedToTenure'_
+2. PersonUpdatedEvent
+3. AccountCreatedEvent
+
+Due to how the MMH data is structured and stored, some of the Person DynamoDB table information is duplicated
+into the Tenure DynamoDB document under HouseholdMembers key in a form of Person objects rather than being
+referenced through GUIDs.
+
+* As a consequence of the architecture, a Tenure Listener is needed to append new people to HouseholdMembers
+whenever they're added. _(PersonCreatedEvent V1)_
+
+* As a consequence of Tenure document duplicating Person data rather than referencing it via Id, a Tenure Listener
+is needed to perform the behind-the-curtain Person data plumbing to keep the Tenure and Person DynamoDB tables in
+sync _(PersonUpdatedEvent)_.
+
+* Due to a similar issue as with Person data duplication, a Tenure listener is needed to sync the Payment Reference
+Number (PRN) duplicated within Tenure DynamoDB document with the number that gets generated for the _(finance)_
+Account DynamoDB document _(AccountCreatedEvent)_.

--- a/TenureListener.Tests/Dockerfile
+++ b/TenureListener.Tests/Dockerfile
@@ -8,15 +8,10 @@ ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 
 WORKDIR /app
 
-COPY ./TenureListener.sln ./
-COPY ./TenureListener/TenureListener.csproj ./TenureListener/
-COPY ./TenureListener.Tests/TenureListener.Tests.csproj ./TenureListener.Tests/
-COPY /NuGet.Config /root/.nuget/NuGet/NuGet.Config
+COPY . .
 
 RUN dotnet restore ./TenureListener/TenureListener.csproj
 RUN dotnet restore ./TenureListener.Tests/TenureListener.Tests.csproj
-
-COPY . .
 
 RUN dotnet build -c Release -o out TenureListener/TenureListener.csproj
 RUN dotnet build -c debug -o out TenureListener.Tests/TenureListener.Tests.csproj

--- a/TenureListener.Tests/Dockerfile
+++ b/TenureListener.Tests/Dockerfile
@@ -12,7 +12,6 @@ COPY . .
 
 RUN dotnet restore
 
-RUN dotnet build -c Release -o out TenureListener/TenureListener.csproj
-RUN dotnet build -c debug -o out TenureListener.Tests/TenureListener.Tests.csproj
+RUN dotnet build
 
 ENTRYPOINT ["dotnet", "test", "--collect", "XPlat Code Coverage;Format=opencover", "--results-directory", "./coverage"]

--- a/TenureListener.Tests/Dockerfile
+++ b/TenureListener.Tests/Dockerfile
@@ -10,8 +10,6 @@ WORKDIR /app
 
 COPY . .
 
-RUN dotnet restore
-
 RUN dotnet build
 
 ENTRYPOINT ["dotnet", "test", "--collect", "XPlat Code Coverage;Format=opencover", "--results-directory", "./coverage"]

--- a/TenureListener.Tests/Dockerfile
+++ b/TenureListener.Tests/Dockerfile
@@ -10,8 +10,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN dotnet restore ./TenureListener/TenureListener.csproj
-RUN dotnet restore ./TenureListener.Tests/TenureListener.Tests.csproj
+RUN dotnet restore
 
 RUN dotnet build -c Release -o out TenureListener/TenureListener.csproj
 RUN dotnet build -c debug -o out TenureListener.Tests/TenureListener.Tests.csproj

--- a/TenureListener.Tests/Dockerfile
+++ b/TenureListener.Tests/Dockerfile
@@ -1,6 +1,5 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0
 
-# disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
 ENV DynamoDb_LocalMode='true'
@@ -9,7 +8,6 @@ ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 
 WORKDIR /app
 
-# Copy csproj and restore as distinct layers
 COPY ./TenureListener.sln ./
 COPY ./TenureListener/TenureListener.csproj ./TenureListener/
 COPY ./TenureListener.Tests/TenureListener.Tests.csproj ./TenureListener.Tests/
@@ -18,7 +16,6 @@ COPY /NuGet.Config /root/.nuget/NuGet/NuGet.Config
 RUN dotnet restore ./TenureListener/TenureListener.csproj
 RUN dotnet restore ./TenureListener.Tests/TenureListener.Tests.csproj
 
-# Copy everything else and build
 COPY . .
 
 RUN dotnet build -c Release -o out TenureListener/TenureListener.csproj


### PR DESCRIPTION
# What:
 - Bump pipeline's node.js from v18 to v22 by using CCI orb.
 - Trim down the Dockerfile to make Sonar scan happy.
 - Add information on what the application does to the README.

# Why:
 - Main reason for creating this PR is to trigger and re-trigger the Sonar Scan over and over again to test whether the Github integration configuration has started working or not whilst doing the Web UI changes.
 - Improved README so it's clear what events this listener processes, what the processing does, and why.

# Notes:
 - It turns out this project has been misconfigured on the Sonar Cloud end onto a duplicate project key that had to be deleted for the Github integration to be configurable via repository binding.